### PR TITLE
HorizontalSelector bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.4.1"
 }
 
 repositories {

--- a/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/DataSource.kt
+++ b/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/DataSource.kt
@@ -1,0 +1,17 @@
+package com.realwear.uxlibrary_example.horizontalselectorexample
+
+object DataSource {
+    val arr = arrayOf(
+        TestColor.Black,
+        TestColor.Brown,
+        TestColor.Red,
+        TestColor.Orange,
+        TestColor.Yellow,
+        TestColor.Green,
+        TestColor.Cyan,
+        TestColor.Blue,
+        TestColor.Violet,
+        TestColor.Gray,
+        TestColor.White
+    )
+}

--- a/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/ExampleAdapter.kt
+++ b/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/ExampleAdapter.kt
@@ -44,20 +44,7 @@ class ExampleAdapter(context: Context) :
     HorizontalSelectorAdapter<ExampleViewHolder>(context) {
     private val weakContext: WeakReference<Context> = WeakReference(context)
     private val localTag = ExampleAdapter::class.java.simpleName
-
-    private val arr = arrayOf(
-        TestColor.Black,
-        TestColor.Brown,
-        TestColor.Red,
-        TestColor.Orange,
-        TestColor.Yellow,
-        TestColor.Green,
-        TestColor.Cyan,
-        TestColor.Blue,
-        TestColor.Violet,
-        TestColor.Gray,
-        TestColor.White
-    )
+    private var arr: Array<TestColor> = emptyArray()
 
     override fun onCreateViewHolder(parent: ViewGroup): ExampleViewHolder {
         return ExampleViewHolder(
@@ -104,6 +91,13 @@ class ExampleAdapter(context: Context) :
             1 -> ColorLevelFragment(arr[position].name)
             else -> null
         }
+    }
+
+    fun updateArray(array: Array<TestColor>) {
+        arr = array
+
+        // FIXME: When adapter is updated from LiveData items sometimes are not fully inflated
+        notifyDataSetChanged()
     }
 }
 

--- a/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/FragmentHorizontalSelectorExample.kt
+++ b/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/FragmentHorizontalSelectorExample.kt
@@ -93,7 +93,9 @@ class CustomDialogFragment : DialogFragment() {
         )
         val view = binding.root
 
-        binding.horizontalSelector.setAdapter(ExampleAdapter(weakContext.get()!!))
+        val adapter = ExampleAdapter(weakContext.get()!!)
+        binding.horizontalSelector.setAdapter(adapter)
+        adapter.updateArray(DataSource.arr) // No ViewModel - no bug
 
         /**
          * Method demonstrating how to get the index of the focused item.

--- a/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/HorizontalSelectorExampleActivity.kt
+++ b/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/HorizontalSelectorExampleActivity.kt
@@ -10,6 +10,7 @@ package com.realwear.uxlibrary_example.horizontalselectorexample
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.realwear.uxlibrary_example.R
 import com.realwear.uxlibrary_example.databinding.ActivityHorizontalSelectorBinding
@@ -19,6 +20,10 @@ import com.realwear.uxlibrary_example.databinding.ActivityHorizontalSelectorBind
  */
 class HorizontalSelectorExampleActivity : AppCompatActivity() {
     private lateinit var binding: ActivityHorizontalSelectorBinding
+
+    private val viewModel by viewModels<HorizontalSelectorExampleViewModel>()
+    private val adapter = ExampleAdapter(this)
+
     private var centerBorderVisibility = View.VISIBLE
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,7 +31,11 @@ class HorizontalSelectorExampleActivity : AppCompatActivity() {
         binding = ActivityHorizontalSelectorBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.horizontalSelector.setAdapter(ExampleAdapter(this))
+        binding.horizontalSelector.setAdapter(adapter)
+        viewModel.getArray().observe(this) {
+            // FIXME: ViewModel observing causes bug with items
+            adapter.updateArray(it)
+        }
     }
 
     /**

--- a/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/HorizontalSelectorExampleViewModel.kt
+++ b/app/src/main/java/com/realwear/uxlibrary_example/horizontalselectorexample/HorizontalSelectorExampleViewModel.kt
@@ -1,0 +1,12 @@
+package com.realwear.uxlibrary_example.horizontalselectorexample
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.liveData
+import kotlinx.coroutines.Dispatchers
+
+class HorizontalSelectorExampleViewModel : ViewModel() {
+
+    fun getArray() = liveData(Dispatchers.IO) {
+        emit(DataSource.arr)
+    }
+}


### PR DESCRIPTION
HorizontalSelector has a bug with showing items when an adapter is updated from the LiveData observer. Sometimes it works fine, sometimes layout for items is not fully loaded and it shows only Command and State. HorizontalSelectorExampleActivity has LiveData implementation and the bug reproduces. FragmentHorizontalSelectorExample doesn't have LiveData implementation and the bug doesn't reproduce. I think the problem is inside of notifyDataSetChanged().

The real use-case scenario: Inject an adapter into Activity using Hilt. Observe changes with LiveData from the network or database and update an adapter when new data come.

See this video to understand what it looks like:
https://www.youtube.com/watch?v=S_ZIjq9NKVs

UXLibrary version: 1.5.0.493
Device: Navigator 500

This PR doesn't fix the bug! I don't have access to library code, so I reproduce the state where this bug appears and you can try it. Please, open the Issues page for this repository!